### PR TITLE
LIBITD-1508. Add --flatten option.

### DIFF
--- a/archiver/__main__.py
+++ b/archiver/__main__.py
@@ -67,6 +67,11 @@ def main():
         default=batch.DEFAULT_CHUNK_SIZE
     )
     deposit_parser.add_argument(
+        '-f', '--flatten',
+        action='store_true',
+        help='Discard relative path in keypath'
+    )
+    deposit_parser.add_argument(
         '-l', '--logs',
         action='store',
         help='Location to store log files',

--- a/archiver/batch.py
+++ b/archiver/batch.py
@@ -72,7 +72,7 @@ class Batch:
     and an AWS configuration where they will be archived.
     """
 
-    def __init__(self, path, bucket, asset_root, name=None, log_dir=None):
+    def __init__(self, path, bucket, asset_root, name=None, log_dir=None, flatten=False):
         """
         Set up a batch of assets to be loaded. Any assets whose local paths don't exist are omitted from the batch.
         """
@@ -93,6 +93,7 @@ class Batch:
         self.results_filename = os.path.join(self.log_dir, 'results.csv')
         self.manifest_filename = None
         self.contents = []
+        self.flatten = flatten
 
         self.stats = {
             'batch_name': self.name,
@@ -128,6 +129,20 @@ class Batch:
                     md5, path = line.strip().split(None, 1)
                     if (md5, path) not in completed:
                         self.add_asset(path, md5)
+
+    def filename_collision(self, manifest):
+        """Check for uniqueness of filenames in manifest"""
+        all_filenames = set()
+        self.manifest_filename = os.path.join(self.path, manifest)
+        with open(self.manifest_filename) as manifest_file:
+            for line in manifest_file:
+                if line is not '':
+                    filename = os.path.basename(line.strip().split(None, 1)[1])
+                    if filename in all_filenames:
+                        return True
+                    else:
+                        all_filenames.add(filename)
+        return False
 
     def add_asset(self, path, md5=None):
         try:
@@ -169,7 +184,8 @@ class Batch:
             f'  - Chunk Size: {chunk_size} ({chunk_bytes} bytes)\n'
             f'  - Use Threads: {use_threads}\n'
             f'  - Max Threads: {max_threads}\n'
-            f'  - AWS Profile: {profile_name}\n\n'
+            f'  - AWS Profile: {profile_name}\n'
+            f'  - Flatten: {self.flatten}\n\n'
         )
 
         begin = datetime.now()

--- a/archiver/deposit.py
+++ b/archiver/deposit.py
@@ -16,9 +16,12 @@ def deposit(args):
             name=args.name,
             bucket=args.bucket,
             asset_root=args.root,
-            log_dir=args.logs
+            log_dir=args.logs,
+            flatten=args.flatten
         )
         if args.mapfile is not None:
+            if batch.filename_collision(args.mapfile):
+                raise ConfigException(f'Error: {batch.name} contains duplicate filenames.')
             batch.load_manifest(args.mapfile)
         else:
             batch.add_asset(args.asset)
@@ -65,7 +68,8 @@ def batch_deposit(args):
                     bucket=config.get('bucket'),
                     asset_root=config.get('asset_root'),
                     name=config.get('name'),
-                    log_dir=config.get('logs')
+                    log_dir=config.get('logs'),
+                    flatten=config.get('flatten')
                 )
                 batch.load_manifest(config.get('manifest', DEFAULT_MANIFEST_FILENAME))
             except ConfigException as e:


### PR DESCRIPTION
Adds (-f, --flatten) option to the deposit command.  This option is also accessible through YAML config in the batch_deposit command (and therefore does not collide with the latter command's -f option).  Includes a batch method that checks for filename collisions before processing the manifest file, and raises a ConfigException if a collision is found.

https://issues.umd.edu/browse/LIBITD-1508