### PR TITLE
LIBITD-1550. Fixed issue when optional "asset_root" parameter is not provided

### DIFF
--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -1,8 +1,7 @@
 import hashlib
 import os
-import re
-
-from .exceptions import ConfigException, PathOutOfScopeException
+from .exceptions import ConfigException
+from .utils import calculate_relative_path
 
 GB = 1024 ** 3
 
@@ -24,30 +23,7 @@ class Asset:
         if relpath:
             self.relpath = relpath
         else:
-            self.relpath = Asset.calculate_relative_path(batch_root, self.local_path)
-
-    @staticmethod
-    def calculate_relative_path(batch_root, local_path):
-        """
-        Returns the relative path, i.e., the given local_path with the
-        given batch_root prefix removed.
-
-        :param batch_root: the path prefix to remove from the local path
-        :param local_path: the local path to the file
-        :return: the path relative to the batch_root
-        :raises: PathOutOfScopeException if the given local_path does not match
-                 the given batch_root
-        """
-        if not batch_root.endswith('/'):
-            batch_root += '/'
-
-        batch_root_pattern = re.compile('(' + batch_root + ')')
-
-        match = batch_root_pattern.match(local_path)
-        if match:
-            return local_path[len(match[1]):]
-        else:
-            raise PathOutOfScopeException(path=local_path, base_path=batch_root)
+            self.relpath = calculate_relative_path(batch_root, self.local_path)
 
     def calculate_md5(self):
         """

--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -11,7 +11,7 @@ class Asset:
     Class representing a binary resource to be archived.
     """
 
-    def __init__(self, path, batch_root, md5=None, relpath=None):
+    def __init__(self, path, md5=None, relpath=None):
         self.local_path = path
         self.md5        = md5 or self.calculate_md5()
         self.filename   = os.path.basename(self.local_path)
@@ -19,11 +19,7 @@ class Asset:
         self.directory  = os.path.dirname(self.local_path)
         self.bytes      = os.path.getsize(self.local_path)
         self.extension  = os.path.splitext(self.filename)[1].lstrip('.').upper()
-
-        if relpath:
-            self.relpath = relpath
-        else:
-            self.relpath = calculate_relative_path(batch_root, self.local_path)
+        self.relpath = relpath
 
     def calculate_md5(self):
         """

--- a/archiver/batch.py
+++ b/archiver/batch.py
@@ -83,15 +83,15 @@ class Batch:
     and an AWS configuration where they will be archived.
     """
 
-    def __init__(self, path, bucket, asset_root, name=None, log_dir=None):
+    def __init__(self, manifest_path, bucket, asset_root, name=None, log_dir=None):
         """
         Set up a batch of assets to be loaded. Any assets whose local paths don't exist are omitted from the batch.
         """
-        self.path = path
+        self.manifest_path = manifest_path
         if name is not None:
             self.name = name
         else:
-            self.name = os.path.basename(self.path)
+            self.name = os.path.basename(self.manifest_path)
         self.bucket = bucket
 
         if asset_root is None:
@@ -101,7 +101,7 @@ class Batch:
             if not self.asset_root.endswith('/'):
                 self.asset_root += '/'
 
-        self.log_dir = os.path.join(self.path, log_dir if log_dir is not None else DEFAULT_LOG_DIR)
+        self.log_dir = os.path.join(self.manifest_path, log_dir if log_dir is not None else DEFAULT_LOG_DIR)
         if not os.path.isdir(self.log_dir):
             os.mkdir(self.log_dir)
 
@@ -133,7 +133,7 @@ class Batch:
         else:
             completed = set()
 
-        self.manifest_filename = os.path.join(self.path, manifest)
+        self.manifest_filename = os.path.join(self.manifest_path, manifest)
         self.load_manifest_file(self.manifest_filename, completed)
 
     def load_manifest_file(self, manifest_filename, completed):

--- a/archiver/deposit.py
+++ b/archiver/deposit.py
@@ -12,7 +12,7 @@ def deposit(args):
     """Deposit a set of files into AWS."""
     try:
         batch = Batch(
-            path=os.path.dirname(args.mapfile) if args.mapfile else os.path.curdir,
+            manifest_path=os.path.dirname(args.mapfile) if args.mapfile else os.path.curdir,
             name=args.name,
             bucket=args.bucket,
             asset_root=args.root,
@@ -61,7 +61,7 @@ def batch_deposit(args):
         for config in batch_configs['batches']:
             try:
                 batch = Batch(
-                    path=os.path.join(batches_dir, config.get('path')),
+                    manifest_path=os.path.join(batches_dir, config.get('path')),
                     bucket=config.get('bucket'),
                     asset_root=config.get('asset_root'),
                     name=config.get('name'),

--- a/archiver/utils.py
+++ b/archiver/utils.py
@@ -1,0 +1,25 @@
+import re
+from .exceptions import ConfigException, PathOutOfScopeException
+
+
+def calculate_relative_path(batch_root, local_path):
+    """
+    Returns the relative path, i.e., the given local_path with the
+    given batch_root prefix removed.
+
+    :param batch_root: the path prefix to remove from the local path
+    :param local_path: the local path to the file
+    :return: the path relative to the batch_root
+    :raises: PathOutOfScopeException if the given local_path does not match
+             the given batch_root
+    """
+    if not batch_root.endswith('/'):
+        batch_root += '/'
+
+    batch_root_pattern = re.compile('(' + batch_root + ')')
+
+    match = batch_root_pattern.match(local_path)
+    if match:
+        return local_path[len(match[1]):]
+    else:
+        raise PathOutOfScopeException(path=local_path, base_path=batch_root)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -7,24 +7,9 @@ class TestAsset(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_asset_for_sample_file(self):
-        sample_file_path = 'tests/data/files/sample_file_1.txt'
-        asset = Asset(sample_file_path, 'tests/data/', md5='SAMPLE_MD5')
-
-        expected_bytes = os.path.getsize(sample_file_path)
-        expected_mtime = int(os.path.getmtime(sample_file_path))
-
-        self.assertEqual(sample_file_path, asset.local_path)
-        self.assertEqual('SAMPLE_MD5', asset.md5)
-        self.assertEqual('sample_file_1.txt', asset.filename)
-        self.assertEqual('tests/data/files', asset.directory)
-        self.assertEqual('files/sample_file_1.txt', asset.relpath)
-        self.assertEqual(expected_bytes, asset.bytes)
-        self.assertEqual(expected_mtime, asset.mtime)
-
     def test_asset_for_sample_file_with_provided_relpath(self):
         sample_file_path = 'tests/data/files/sample_file_1.txt'
-        asset = Asset(sample_file_path, 'tests/data/', md5='SAMPLE_MD5', relpath="foo/bar/sample_file_1.txt")
+        asset = Asset(sample_file_path, md5='SAMPLE_MD5', relpath="foo/bar/sample_file_1.txt")
 
         expected_bytes = os.path.getsize(sample_file_path)
         expected_mtime = int(os.path.getmtime(sample_file_path))

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from archiver.asset import Asset
-from archiver.exceptions import PathOutOfScopeException
+
 
 class TestAsset(unittest.TestCase):
     def setUp(self):
@@ -36,17 +36,3 @@ class TestAsset(unittest.TestCase):
         self.assertEqual('foo/bar/sample_file_1.txt', asset.relpath)
         self.assertEqual(expected_bytes, asset.bytes)
         self.assertEqual(expected_mtime, asset.mtime)
-
-    def test_calculate_relative_path(self):
-        test_cases = [
-            dict(batch_root='/', local_path='/foo/bar/quuz/test.txt', expected='foo/bar/quuz/test.txt'),
-            dict(batch_root='/foo', local_path='/foo/bar/quuz/test.txt', expected='bar/quuz/test.txt'),
-            dict(batch_root='/foo/bar', local_path='/foo/bar/quuz/test.txt', expected='quuz/test.txt'),
-        ]
-
-        for t in test_cases:
-            relative_path = Asset.calculate_relative_path(t['batch_root'], t['local_path'])
-            self.assertEqual(t['expected'], relative_path, f"Failed test_case: {t}")
-
-        with self.assertRaises(PathOutOfScopeException):
-            relative_path = Asset.calculate_relative_path('/foo/bar', '/abc/def/ghi/text.txt')

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -8,13 +8,13 @@ class TestBatch(unittest.TestCase):
         pass
 
     def test_load_md5sum_manifest(self):
-        batch = Batch(path='tests/data/manifests', bucket='test_bucket', asset_root='/', log_dir='/tmp')
+        batch = Batch(manifest_path='tests/data/manifests', bucket='test_bucket', asset_root='/', log_dir='/tmp')
         batch.load_manifest('sample_md5sum_manifest.txt')
         self.assertEqual(5, batch.stats['total_assets'])
         self.assertEqual(5, batch.stats['assets_missing'])
 
     def test_load_patsy_manifest(self):
-        batch = Batch(path='tests/data/manifests', bucket='test_bucket', asset_root='/', log_dir='/tmp')
+        batch = Batch(manifest_path='tests/data/manifests', bucket='test_bucket', asset_root='/', log_dir='/tmp')
         batch.load_manifest('sample_patsy_manifest.csv')
         self.assertEqual(5, batch.stats['total_assets'])
         self.assertEqual(5, batch.stats['assets_missing'])
@@ -29,7 +29,7 @@ class TestBatch(unittest.TestCase):
     def test_add_asset_without_specified_relpath(self):
         sample_file_1_path = os.path.abspath('tests/data/files/sample_file_1.txt')
         asset_root = os.path.abspath('.')
-        batch = Batch(path=sample_file_1_path, bucket='test_bucket', asset_root=asset_root, log_dir='/tmp')
+        batch = Batch(manifest_path=sample_file_1_path, bucket='test_bucket', asset_root=asset_root, log_dir='/tmp')
 
         batch.add_asset(sample_file_1_path)
 
@@ -41,7 +41,7 @@ class TestBatch(unittest.TestCase):
     def test_add_asset_with_specified_relpath(self):
         sample_file_1_path = os.path.abspath('tests/data/files/sample_file_1.txt')
         asset_root = os.path.abspath('.')
-        batch = Batch(path=sample_file_1_path, bucket='test_bucket', asset_root=asset_root, log_dir='/tmp')
+        batch = Batch(manifest_path=sample_file_1_path, bucket='test_bucket', asset_root=asset_root, log_dir='/tmp')
 
         batch.add_asset(sample_file_1_path, relpath='test/specific/relpath/sample_file_1.txt')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import unittest
+from archiver.asset import Asset
+from archiver.exceptions import PathOutOfScopeException
+from archiver.utils import calculate_relative_path
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_calculate_relative_path(self):
+        test_cases = [
+            dict(batch_root='/', local_path='/foo/bar/quuz/test.txt', expected='foo/bar/quuz/test.txt'),
+            dict(batch_root='/foo', local_path='/foo/bar/quuz/test.txt', expected='bar/quuz/test.txt'),
+            dict(batch_root='/foo/bar', local_path='/foo/bar/quuz/test.txt', expected='quuz/test.txt'),
+        ]
+
+        for t in test_cases:
+            relative_path = calculate_relative_path(t['batch_root'], t['local_path'])
+            self.assertEqual(t['expected'], relative_path, f"Failed test_case: {t}")
+
+        with self.assertRaises(PathOutOfScopeException):
+            relative_path = calculate_relative_path('/foo/bar', '/abc/def/ghi/text.txt')


### PR DESCRIPTION
Moved "calculate_relative_path" method out of the "Assets" class into "utils.py".

Refactored the code to move relpath calculation out of the "Asset" class and into the "Batch" class, so that an asset is constructed with the relpath directly. This simplifies the "Asset" class, and puts the relpath calculation into the Batch class, which already has all the information needed to do the calculation.

Renamed the "path" instance variable in "Batch" to "manifest_path", so that it would be clearer what the variable represented. Also avoids potential confusion in the "add_asset" method, where "path" is used as a variable that is a method argument.

https://issues.umd.edu/browse/LIBITD-1550