### PR TITLE
LIBITD-1554. "calculate_etag" returns Asset MD5 for unchunked files

### DIFF
--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -38,10 +38,20 @@ class Asset:
         together, followed by the number of chunks.
         """
         file_size = os.path.getsize(self.local_path)
+
         if file_size == 0:
             # Special handling for zero byte files, just return the MD5 sum of
             # an empty string
             return hashlib.md5(b'').hexdigest()
+
+        # Min unchunked file_size is the smaller of chunk_size and GB
+        min_unchunked_file_size = min(chunk_size, GB)
+
+        # For files that are small enough not to be chunked, simply return
+        # the asset MD5
+        use_asset_md5 = (file_size < min_unchunked_file_size) and self.md5
+        if use_asset_md5:
+            return self.md5
 
         md5s = []
         with open(self.local_path, 'rb') as handle:

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,11 +1,16 @@
 import os
 import unittest
+from unittest.mock import patch
+import archiver.asset
 from archiver.asset import Asset
+from archiver.exceptions import ConfigException
 
 
 class TestAsset(unittest.TestCase):
     def setUp(self):
-        pass
+        # Some tests reset the "archiver.asset.GB" variable, so store
+        # the original value so we can reset it in "tearDown"
+        self.original_GB = archiver.asset.GB
 
     def test_asset_for_sample_file_with_provided_relpath(self):
         sample_file_path = 'tests/data/files/sample_file_1.txt'
@@ -37,8 +42,51 @@ class TestAsset(unittest.TestCase):
 
     def test_etag_for_chunked_file(self):
         file_path = 'tests/data/files/sample_file_1.txt'
-        asset = Asset(file_path)
-        # Chunk every byte
-        etag = asset.calculate_etag(1)
+
+        # Report file size as is larger than Asset.GB to force chunking
+        mock_file_size = archiver.asset.GB + 1
+        with unittest.mock.patch('os.path.getsize', return_value=mock_file_size):
+            asset = Asset(file_path)
+            # Chunk every byte
+            etag = asset.calculate_etag(1)
 
         self.assertEqual('90d341c0ca6509f2a82783bdcb806bbb-4', etag)
+
+    def test_etag_for_chunked_file_where_chunk_size_is_larger_than_asset_GB(self):
+        file_path = 'tests/data/files/sample_file_1.txt'
+
+        asset = Asset(file_path)
+
+        # Reset archiver.asset.GB to 1 byte, so that we don't have to have
+        # a huge file to do the test
+        archiver.asset.GB = 1
+
+        # Chunk every 2 bytes
+        etag = asset.calculate_etag(2)
+
+        self.assertEqual('0bbe9c3c497cd97da0754e9be0f7ed59-2', etag)
+
+    def test_raises_config_error_if_chunk_size_not_multiple_of_GB(self):
+        file_path = 'tests/data/files/sample_file_1.txt'
+        asset = Asset(file_path)
+
+        # chunk_size is larger than Asset.GB, and not a multiple
+        chunk_size = archiver.asset.GB + 1
+
+        # Report file size as 2 chunks
+        mock_file_size = chunk_size * 2
+        with unittest.mock.patch('os.path.getsize', return_value=mock_file_size):
+            with self.assertRaises(ConfigException):
+                etag = asset.calculate_etag(chunk_size)
+
+    def test_skips_md5_calculation_for_unchunked_files(self):
+        file_path = 'tests/data/files/sample_file_1.txt'
+        asset = Asset(file_path)
+        asset.md5 = "MD5_FROM_ASSET"
+        etag = asset.calculate_etag(10)
+        self.assertEqual("MD5_FROM_ASSET", etag)
+
+    def tearDown(self) -> None:
+        # Restore the "archiver.asset.GB" to its original value,
+        # in case it was modified in a test.
+        archiver.asset.GB = self.original_GB


### PR DESCRIPTION
Modified "calculate_etag" method to return the Asset MD5 if the file
is small enough that it does not need to be chunked. This should speed
up the transfers, as the MD5 will only be calculated for chunked files,
instead of every file.

https://issues.umd.edu/browse/LIBITD-1554