### PR TITLE
Feature/libitd 1988

### DIFF
--- a/archiver/__main__.py
+++ b/archiver/__main__.py
@@ -76,7 +76,7 @@ def main():
         '-n', '--name',
         action='store',
         help='Batch identifier or name',
-        default='test_batch'
+        default=None
     )
     deposit_parser.add_argument(
         '-p', '--profile',

--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -11,8 +11,9 @@ class Asset:
     Class representing a binary resource to be archived.
     """
 
-    def __init__(self, path, md5=None, relpath=None, manifest_row=None, etag=None):
+    def __init__(self, path, batch_name=None, md5=None, relpath=None, manifest_row=None, etag=None):
         self.local_path = path
+        self.batch_name = batch_name
         self.md5 = md5 or self.calculate_md5()
         self.filename = os.path.basename(self.local_path)
         self.mtime = int(os.path.getmtime(self.local_path))

--- a/archiver/deposit.py
+++ b/archiver/deposit.py
@@ -102,7 +102,6 @@ def batch_deposit(args):
                 raise FailureException from e
 
             print()
-            print(f'Batch: {batch.name}')
             batch.deposit(
                 profile_name=args.profile,
                 chunk_size=config.get('chunk_size'),

--- a/archiver/manifests/inventory_manifest.py
+++ b/archiver/manifests/inventory_manifest.py
@@ -10,16 +10,6 @@ class InventoryManifest(Manifest):
     def __init__(self, manifest_filename):
         self.manifest_filename = manifest_filename
         self.manifest_path = os.path.dirname(manifest_filename)
-        with open(self.manifest_filename, 'r') as manifest_file:
-            results = csv.DictReader(manifest_file)
-            first_row = next(results)
-            self.batch_name = first_row.get('BATCH')
-
-    def batch_name(self):
-        """
-        Returns the batch name specified on the first row of the manifest
-        """
-        return self.batch_name
 
     def load_manifest(self, results_filename, batch, etag_exists=False):
         if os.path.isfile(results_filename):
@@ -36,5 +26,6 @@ class InventoryManifest(Manifest):
                 md5 = row['MD5']
                 path = row['PATH']
                 relpath = row['RELPATH']
+                batch_name = row['BATCH']
                 if (md5, path) not in completed:
-                    batch.add_asset(path, md5, relpath=relpath, manifest_row=row, etag=etag)
+                    batch.add_asset(path, batch_name=batch_name, md5=md5, relpath=relpath, manifest_row=row, etag=etag)

--- a/archiver/manifests/manifest.py
+++ b/archiver/manifests/manifest.py
@@ -5,13 +5,6 @@ class Manifest(metaclass=abc.ABCMeta):
     """
     An interface for manifests.
     """
-    @abc.abstractmethod
-    def batch_name(self):
-        """
-        Returns the batch name associated with the manifest, or None if the
-        batch name is not specified by the manifest
-        """
-        return None
 
     @abc.abstractmethod
     def load_manifest(self, results_filename, batch):

--- a/archiver/manifests/md5_sum_manifest.py
+++ b/archiver/manifests/md5_sum_manifest.py
@@ -12,12 +12,6 @@ class Md5SumManifest(Manifest):
         self.manifest_filename = manifest_filename
         self.manifest_path = os.path.dirname(manifest_filename)
 
-    def batch_name(self):
-        """
-        Returns None, as MD5 Sum manifest does not specify the batch name
-        """
-        return None
-
     def load_manifest(self, results_filename, batch):
         if os.path.isfile(results_filename):
             with open(results_filename, 'r') as results_file:
@@ -35,4 +29,4 @@ class Md5SumManifest(Manifest):
                     md5, path = line.strip().split(None, 1)
                     manifest_row = {'MD5': md5, 'PATH': path}
                     if (md5, path) not in completed:
-                        batch.add_asset(path, md5, manifest_row=manifest_row)
+                        batch.add_asset(path, md5=md5, manifest_row=manifest_row)

--- a/archiver/manifests/patsy_db_manifest.py
+++ b/archiver/manifests/patsy_db_manifest.py
@@ -11,12 +11,6 @@ class PatsyDbManifest(Manifest):
         self.manifest_filename = manifest_filename
         self.manifest_path = os.path.dirname(manifest_filename)
 
-    def batch_name(self):
-        """
-        Returns None, as Pasty DB manifest does not specify the batch
-        """
-        return None
-
     def load_manifest(self, results_filename, batch):
         if os.path.isfile(results_filename):
             with open(results_filename, 'r') as results_file:
@@ -32,4 +26,4 @@ class PatsyDbManifest(Manifest):
                 path = row['filepath']
                 relpath = row['relpath']
                 if (md5, path) not in completed:
-                    batch.add_asset(path, md5, relpath=relpath, manifest_row=row)
+                    batch.add_asset(path, md5=md5, relpath=relpath, manifest_row=row)

--- a/archiver/manifests/single_asset_manifest.py
+++ b/archiver/manifests/single_asset_manifest.py
@@ -11,12 +11,6 @@ class SingleAssetManifest(Manifest):
         self.manifest_filename = manifest_filename
         self.manifest_path = os.path.dirname(manifest_filename)
 
-    def batch_name(self):
-        """
-        Returns None, as Single Asset manifest does not specify the batch name
-        """
-        return None
-
     def load_manifest(self, results_filename, batch):
         """
         Does nothing. Asset must be added to Batch manually


### PR DESCRIPTION
Moved batch names to be set at the asset level. 
Removed code from manifests for setting the batch name.
Changed logic for creating the keypath for deposits.

https://umd-dit.atlassian.net/browse/LIBITD-1988