### PR TITLE
LIBITD-2326. Align CSV header field names to LIBITD-2325 standard

### DIFF
--- a/archiver/batch.py
+++ b/archiver/batch.py
@@ -241,7 +241,6 @@ class Batch:
                     f'    ETAG: {expected_etag}\n\n'
                 )
 
-
                 # Send the file, optionally in multipart, multithreaded mode
                 progress_tracker = ProgressPercentage(asset, self)
                 self.stats['assets_transmitted'] += 1

--- a/archiver/batch.py
+++ b/archiver/batch.py
@@ -183,14 +183,14 @@ class Batch:
         if self.manifest.manifest_filename:
             results_file_exists = os.path.exists(self.results_filename)
             results_file = open(self.results_filename, 'a')
-            fieldnames = ['id']
+            fieldnames = ['ID']
             # Include fields from the manifest in the results file
             if (len(self.contents) > 0):
                 first_asset = self.contents[0]
                 manifest_row = first_asset.manifest_row
                 if manifest_row:
                     fieldnames.extend(manifest_row.keys())
-            fieldnames.extend(['keypath', 'etag', 'result', 'storageprovider', 'storagepath'])
+            fieldnames.extend(['KEYPATH', 'ETAG', 'RESULT', 'STORAGEPROVIDER', 'STORAGELOCATION'])
             writer = csv.DictWriter(results_file, fieldnames=fieldnames)
             if not results_file_exists:
                 writer.writeheader()
@@ -213,7 +213,7 @@ class Batch:
                 else:
                     print(f'Using the manifestpath {self.manifest.manifest_path}')
                     key_path = f'{self.manifest.manifest_path}/{asset.relpath}'
-                
+
                 # Check if ETAG exists
                 if asset.etag is not None and asset.etag != '':
                     expected_etag = asset.etag
@@ -297,12 +297,12 @@ class Batch:
                     result = 'failed'
 
                 row = {
-                    'id': n,
-                    'keypath': key_path,
-                    'etag': remote_etag,
-                    'result': result,
-                    'storageprovider': 'AWS',
-                    'storagepath': f'{self.bucket}/{key_path}'
+                    'ID': n,
+                    'KEYPATH': key_path,
+                    'ETAG': remote_etag,
+                    'RESULT': result,
+                    'STORAGEPROVIDER': 'AWS',
+                    'STORAGELOCATION': f'{self.bucket}/{key_path}'
                 }
                 if asset.manifest_row:
                     row.update(asset.manifest_row)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pycodestyle]
 max-line-length=120
+exclude = .venv


### PR DESCRIPTION
Modified the CSV header field names to align with the standard specified
in LIBITD-2325 -- the field names are upper-case, and
"storagepath" is renamed to "STORAGELOCATION".

https://umd-dit.atlassian.net/browse/LIBITD-2326